### PR TITLE
Add Cpu code to samples for Black-Scholes and Dot Product project to all...

### DIFF
--- a/samples/BlackScholes.CSharp/Program.cs
+++ b/samples/BlackScholes.CSharp/Program.cs
@@ -9,6 +9,7 @@ using Nessos.GpuLinq.CSharp;
 using Nessos.GpuLinq.Core;
 using FMath = Nessos.GpuLinq.Core.Functions.Math;
 using System.Runtime.InteropServices;
+using System.Diagnostics;
 namespace BlackScholes.CSharp
 {
     class Program
@@ -26,7 +27,77 @@ namespace BlackScholes.CSharp
         {
             public float Call;
             public float Put;
+
+            public override string ToString() { return String.Format("C:{0:0.###}  P:{1:0.###}", Call, Put); }
+            public bool IsEqual(OutPutData rhs)
+            {
+                return this.Call == rhs.Call && this.Put == rhs.Put;
+            }
         }
+
+        struct Results
+        {
+            public OutPutData Cpu;
+            public OutPutData Gpu;
+            public override string ToString()
+            {
+                return String.Format("\nCpu : {0}  Gpu : {1}", Cpu, Gpu);
+            }
+        }
+        
+        static OutPutData[] CpuBlackScholes(InputData[] data)
+        {
+            const int optionCount = 1000000;
+            const double riskFreeInterestRate = 0.02;
+            const double volatility = 0.30;
+            const double A1 = 0.31938153;
+            const double A2 = -0.356563782;
+            const double A3 = 1.781477937;
+            const double A4 = -1.821255978;
+            const double A5 = 1.330274429;
+
+            Func<double, double> k =  x => 1.0 / (1.0 + 0.2316419 * Math.Abs(x));
+            Func<double, double> cnd =  x =>
+                {
+                    var v = k.Invoke(x);
+                    return 1.0 - 1.0 / Math.Sqrt(2.0 * Math.PI)
+                    * Math.Exp(-(Math.Abs(x)) * (Math.Abs(x)) / 2.0) * (A1 * v + A2 * v * v + A3 * Math.Pow(v, 3)
+                    + A4 * Math.Pow(v, 4) + A5 * Math.Pow(v, 5));
+                };
+
+            Func<double, double> cumulativeNormalDistribution = x => (x < 0.0) ? 1.0 - cnd.Invoke(x) : cnd.Invoke(x);
+
+
+            Func<double, double, double, double> d1 =
+                (stockPrice, strikePrice, timeToExpirationYears) =>
+                    Math.Log((stockPrice / strikePrice) + (riskFreeInterestRate + volatility * volatility / 2.0)) * timeToExpirationYears
+                    / (volatility * Math.Sqrt(timeToExpirationYears));
+
+            Func<double, double, double> d2 =
+                (_d1, timeToExpirationYears) => _d1 - volatility * Math.Sqrt(timeToExpirationYears);
+
+            Func<double, double, double, double, double, double> blackScholesCallOption =
+                (_d1, _d2, stockPrice, strikePrice, timeToExpirationYears) =>
+                   (stockPrice * cumulativeNormalDistribution.Invoke(_d1) -
+                    strikePrice * Math.Exp(-(riskFreeInterestRate) * timeToExpirationYears) * cumulativeNormalDistribution.Invoke(_d2));
+
+            Func<double, double, double, double, double, double> blackScholesPutOption =
+               (_d1, _d2, stockPrice, strikePrice, timeToExpirationYears) =>
+                  strikePrice * Math.Exp(-riskFreeInterestRate * timeToExpirationYears) *
+                  cumulativeNormalDistribution.Invoke(-_d2) - stockPrice * cumulativeNormalDistribution.Invoke(-_d1);
+
+            return data.Select(d => 
+                {
+                var _d1 = d1.Invoke((double)d.Stock, (double)d.Strike, (double)d.Times);
+                var _d2 = d2.Invoke(_d1, (double)d.Times);
+                return new OutPutData
+                {
+                    Call = (float)blackScholesCallOption.Invoke(_d1, _d2, d.Stock, d.Strike, d.Times),
+                    Put = (float)blackScholesPutOption.Invoke(_d1, _d2, d.Stock, d.Strike, d.Times)
+                };
+                }).ToArray();
+            }
+        
 
         static void Main(string[] args)
         {
@@ -35,17 +106,20 @@ namespace BlackScholes.CSharp
             const float riskFreeInterestRate = 0.02f;
             const float volatility = 0.30f;
             const float A1 = 0.31938153f;
-            const float A2 =  -0.356563782f;
+            const float A2 = -0.356563782f;
             const float A3 = 1.781477937f;
-            const float A4 =  -1.821255978f;
+            const float A4 = -1.821255978f;
             const float A5 = 1.330274429f;
 
             // Helper functions
             Expression<Func<float, float>> k = x => 1.0f / (1.0f + 0.2316419f * FMath.Abs(x));
-            Expression<Func<float, float>> cnd = x =>
-                    1.0f - 1.0f / FMath.Sqrt(2.0f * FMath.PI)
-                    * FMath.Exp (-(FMath.Abs(x)) * (FMath.Abs(x)) / 2.0f) * (A1 * k.Invoke(x) + A2 * k.Invoke(x) * k.Invoke(x) + A3 * FMath.Pow(k.Invoke(x), 3)
-                    + A4 * FMath.Pow(k.Invoke(x), 4) + A5 * FMath.Pow(k.Invoke(x), 4));
+
+            
+            Expression<Func<float, float>> cnd = x =>     
+                       1.0f - 1.0f / FMath.Sqrt(2.0f * FMath.PI)
+                        * FMath.Exp(-(FMath.Abs(x)) * (FMath.Abs(x)) / 2.0f) * (A1 * k.Invoke(x) + A2 * k.Invoke(x) * k.Invoke(x) + A3 * FMath.Pow(k.Invoke(x), 3)
+                        + A4 * FMath.Pow(k.Invoke(x), 4) + A5 * FMath.Pow(k.Invoke(x), 5));
+                   
 
             Expression<Func<float, float>> cumulativeNormalDistribution = x => (x < 0.0f) ? 1.0f - cnd.Invoke(x) : cnd.Invoke(x);
 
@@ -76,6 +150,9 @@ namespace BlackScholes.CSharp
                                                                             Times = random.Random(0.25f, 10.0f)
                                                                         }).ToArray();
             // Main code
+            Stopwatch timer = new Stopwatch();
+            timer.Start();
+            OutPutData[] results;
             using (GpuContext context = new GpuContext())
             {
                 using(var _data = context.CreateGpuArray(data))
@@ -88,9 +165,26 @@ namespace BlackScholes.CSharp
                                                  Put = blackScholesPutOption.Invoke(_d1, _d2, d.Stock, d.Strike, d.Times)
                          }).ToArray();
 
-                    var result = context.Run(query);
+                    results = context.Run(query);
                 }
             }
+            timer.Stop();
+            var elapsed = timer.ElapsedMilliseconds;
+            Console.WriteLine("Black Scholes computed on Gpu in {0} milliseconds", elapsed); 
+                //String.Join<OutPutData>(", ", Enumerable.Range(1,120).
+               //     Select(i => results.ElementAtOrDefault(i)).ToArray()));
+            timer.Restart();
+            var cpuResults = CpuBlackScholes(data);
+            timer.Stop();
+            elapsed = timer.ElapsedMilliseconds;
+            Console.WriteLine("Black Scholes computed on Cpu in {0} milliseconds", elapsed); 
+            var resultsAreEqual = cpuResults.Zip(results, (a,b) => Tuple.Create(a,b)).All(pair => pair.Item1.IsEqual(pair.Item2));
+            Console.WriteLine("Results calculated by cpu and gpu are {0}", resultsAreEqual ? "equal" : "not equal");
+            Console.WriteLine("Results = {0}",
+                String.Join<Results>(", ", Enumerable.Range(1,120).
+                    Select(i => new Results() { Gpu = results.ElementAtOrDefault(i), Cpu = cpuResults.ElementAtOrDefault(i) } ).ToArray()));
+            Console.ReadLine();
+
         }
     }
     #region Helpers

--- a/samples/DotProduct.CSharp/Program.cs
+++ b/samples/DotProduct.CSharp/Program.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -15,18 +16,43 @@ namespace DotProduct.CSharp
             int size = 1000;
             Random random = new Random();
             var input = Enumerable.Range(1, size).Select(x => (float)random.NextDouble()).ToArray();
+            Stopwatch timer = new Stopwatch();
+            float[] gpuResult;
             using (var context = new GpuContext())
-            {
-
+            {   
                 using (var xs = context.CreateGpuArray(input))
                 {
                     // Dot Product
                     var query = GpuQueryExpr.Zip(xs, xs, (a, b) => a * b).Sum();
-                    var result = context.Run(query);
-                    Console.WriteLine("Result: {0}", result);
+                    timer.Start();
+                    var gpres = context.Run(query);
+                    timer.Stop();
+                    var elapsed = timer.ElapsedTicks;
+                    Console.WriteLine("GPU Computation with compilation took {0} ticks", elapsed);
+                    timer.Restart();
+                    gpuResult = Enumerable.Range(1, 100).Select(i => context.Run(query)).ToArray(); 
+                    timer.Stop();
+                    elapsed = timer.ElapsedTicks;
+                    Console.WriteLine("GPU Computation w/o compilation took {0} ticks", elapsed/100.0);
+                    Console.WriteLine("Result: {0}", gpuResult[0]);
                 }
                 
+                //var elapsed = timer.ElapsedMilliseconds;
+                //Console.WriteLine("GPU Computation took {0} milliseconds", elapsed);
+                
             }
+
+            timer.Restart();
+            var res = Enumerable.Range(1, 100).Select(i =>input.Zip(input, (a, b) => a * b).Sum()).ToArray();
+            timer.Stop();
+            var elapsed2 = timer.ElapsedTicks;
+            Console.WriteLine("CPU Computation took {0} ticks", elapsed2/100.0);
+            if (res[0] == gpuResult[0])
+                Console.WriteLine("Cpu and Gpu computations are identical");
+            else
+                Console.WriteLine("Cpu and Gpu computations are different");
+            Console.ReadLine();
         }
+        
     }
 }


### PR DESCRIPTION
...ow comaprison of Cpu operations vs Gpu operations

Also fixed error in power expansion function where fifth term was multiplied by the power to the fourth place instead of to the fifth place.  
# BlackSholes sample

Cpu calculations differ from Gpu calculations.  Probably because of the use of doubles in the Cpu version since I accessed the Math library instead of the FMath library.
# DotProduct sample Gpu version runs almost 19 times slower than Cpu version this is even after accounting for compilation time of the expression.  No idea why except that possibly the final code emitted to the Gpu is very inefficient.
